### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Production Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    name: "Update release branch"
+    uses: humanmade/hm-github-actions/.github/workflows/build-and-release-node.yml@a9a243d6c42fbff4a967d7ce0a6b307bc77251b7 # v0.1.0
+    with:
+      node_version: 22
+      source_branch: main
+      release_branch: release
+      built_asset_paths: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     name: "Update release branch"
     uses: humanmade/hm-github-actions/.github/workflows/build-and-release-node.yml@a9a243d6c42fbff4a967d7ce0a6b307bc77251b7 # v0.1.0
     with:
-      node_version: 22
+      node_version: 20
       source_branch: main
       release_branch: release
       built_asset_paths: build


### PR DESCRIPTION
This adds the same release action used by humanmade/hm-media-weight, to build code to a `release` branch where it can then be tagged and pushed into packagist, or else consumed directly via a Composer VCS reference.