### PR TITLE
Capitalize HM in plugin description

### DIFF
--- a/hm-mega-menu-block.php
+++ b/hm-mega-menu-block.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name:       Hm Mega Menu Block
+ * Plugin Name:       HM Mega Menu Block
  * Description:       A megamenu block.
  * Version:           1.0
  * Requires at least: 6.5


### PR DESCRIPTION
This is so minor and yet it bugs me! 😎 