### PR TITLE
Add accessibility enhancements for the mega menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
+composer.lock
 /build
 /node_modules
+/vendor
+.DS_Store
+.history

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "hm-mega-menu-block",
-	"version": "1.0.1",
+	"version": "1.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "hm-mega-menu-block",
-			"version": "1.0.1",
+			"version": "1.1.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/icons": "^10.17.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "hm-mega-menu-block",
-	"version": "0.1.0",
+	"version": "1.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "hm-mega-menu-block",
-			"version": "0.1.0",
+			"version": "1.0.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/icons": "^10.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hm-mega-menu-block",
-	"version": "1.0.1",
+	"version": "1.1.1",
 	"description": "An interactive block with the Interactivity API.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/src/render.php
+++ b/src/render.php
@@ -15,7 +15,7 @@ $close_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" widt
 $toggle_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" width="12" height="12" aria-hidden="true" focusable="false" fill="none"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg>';
 ?>
 
-<li <?php echo $wrapper_attributes; ?> data-wp-interactive='{"namespace": "hm-blocks/hm-mega-menu-block" }' data-wp-context='{ "menuOpenedBy": {} }' data-wp-on--keydown="actions.handleMenuKeydown" data-wp-watch="callbacks.initMenu">
+<li <?php echo $wrapper_attributes; ?> data-wp-interactive='{"namespace": "hm-blocks/hm-mega-menu-block" }' data-wp-context='{ "menuOpenedBy": {} }' data-wp-on-document--keydown="actions.handleMenuKeydown" data-wp-on-document--click="actions.handleOutsideClick" data-wp-watch="callbacks.initMenu">
 
 	<button class="wp-block-hm-mega-menu__toggle" data-wp-on--click="actions.toggleMenuOnClick" data-wp-bind--aria-expanded="state.isMenuOpen" style="color:<?php echo $color_label; ?>">
 		<?php echo $label; ?><span class="wp-block-hm-mega-menu__toggle-icon"><?php echo $toggle_icon; ?></span>

--- a/src/view.js
+++ b/src/view.js
@@ -6,16 +6,14 @@ import { store, getContext, getElement } from '@wordpress/interactivity';
 const { state, actions } = store('hm-blocks/hm-mega-menu-block', {
 	state: {
 		get isMenuOpen() {
-			return (
-				Object.values(state.menuOpenedBy).filter(Boolean).length > 0
-			)
+			return Object.values(state.menuOpenedBy).filter(Boolean).length > 0;
 		},
 
 		get menuOpenedBy() {
 			const context = getContext();
 
 			return context.menuOpenedBy;
-		}
+		},
 	},
 
 	actions: {
@@ -24,8 +22,7 @@ const { state, actions } = store('hm-blocks/hm-mega-menu-block', {
 			const { ref } = getElement();
 
 			if (state.menuOpenedBy.click || state.menuOpenedBy.focus) {
-				actions.closeMenu('click');
-				actions.closeMenu('focus');
+				actions.closeMenuOnClick();
 			} else {
 				context.previousFocus = ref;
 				actions.openMenu('click');
@@ -41,10 +38,20 @@ const { state, actions } = store('hm-blocks/hm-mega-menu-block', {
 			if (state.menuOpenedBy.click) {
 				// If Escape close the menu.
 				if (event?.key === 'Escape') {
-					actions.closeMenu('click');
-					actions.closeMenu('focus');
+					actions.closeMenuOnClick();
 				}
 			}
+		},
+
+		handleOutsideClick(event) {
+			const context = getContext();
+			const megaMenu = context?.megaMenu;
+
+			if (!megaMenu || megaMenu.contains(event.target)) {
+				return;
+			}
+
+			actions.closeMenuOnClick();
 		},
 
 		openMenu(menuOpenedOn = 'click') {
@@ -57,9 +64,7 @@ const { state, actions } = store('hm-blocks/hm-mega-menu-block', {
 
 			// Reset the menu reference and button focus when closed.
 			if (!state.isMenuOpen) {
-				if (
-					context.megaMenu?.contains(window.document.activeElement)
-				) {
+				if (context.megaMenu?.contains(window.document.activeElement)) {
 					context.previousFocus?.focus();
 				}
 				context.previousFocus = null;


### PR DESCRIPTION
**Desktop:**

- When a menu item is open, clicking anywhere else on the screen should close the currently open submenu.
- When a menu item is open, clicking on another menu tab should close the currently open submenu and open the newly clicked one.

**Mobile:**

- Only one section can be open at a time. When a user opens a new section, any previously open section should automatically close.
